### PR TITLE
Move Windows config folder

### DIFF
--- a/src/Languages/English.json
+++ b/src/Languages/English.json
@@ -6,6 +6,7 @@
   "exit_button": "Exit",
   "discord_server_button": "Discord Server",
   "languages_button": "Languages",
+  "p2mm_folder": "Open P2:MM Folder",
   "github_button": "GitHub",
   "admins_button": "Admins",
   "settings_button": "Settings",

--- a/src/Languages/Español.json
+++ b/src/Languages/Español.json
@@ -6,6 +6,7 @@
   "exit_button": "Salida",
   "discord_server_button": "Servidor de Discord",
   "languages_button": "Idiomas",
+  "p2mm_folder": "Abra la carpeta P2:MM",
   "github_button": "GitHub",
   "admins_button": "Administradores",
   "settings_button": "Ajustes",

--- a/src/Languages/Français.json
+++ b/src/Languages/Français.json
@@ -6,6 +6,7 @@
   "exit_button": "Sortie",
   "discord_server_button": "Serveur Discord",
   "languages_button": "Langues",
+  "p2mm_folder": "Ouvrez le dossier P2:MM",
   "github_button": "GitHub",
   "admins_button": "Administrateurs",
   "settings_button": "Paramètres",

--- a/src/Languages/Italiano.json
+++ b/src/Languages/Italiano.json
@@ -6,6 +6,7 @@
   "exit_button": "Uscita",
   "discord_server_button": "Server Discord",
   "languages_button": "Lingue",
+  "p2mm_folder": "Apri la cartella P2:MM",
   "github_button": "GitHub",
   "admins_button": "Amministratori",
   "settings_button": "Impostazioni",

--- a/src/Languages/Polski.json
+++ b/src/Languages/Polski.json
@@ -6,6 +6,7 @@
   "exit_button": "Wyjście",
   "discord_server_button": "Serwer Discord",
   "languages_button": "Języki",
+  "p2mm_folder": "Otwórz folder P2:MM",
   "github_button": "GitHub",
   "admins_button": "Administratorzy",
   "settings_button": "Ustawienia",

--- a/src/Languages/Português (Brasil).json
+++ b/src/Languages/Português (Brasil).json
@@ -6,6 +6,7 @@
   "exit_button": "Saída",
   "discord_server_button": "Servidor do Discord",
   "languages_button": "Idiomas",
+  "p2mm_folder": "Abra a pasta P2:MM",
   "github_button": "GitHub",
   "admins_button": "Administradores",
   "settings_button": "Configurações",

--- a/src/Languages/简体中文 (Simplified Chinese).json
+++ b/src/Languages/简体中文 (Simplified Chinese).json
@@ -6,6 +6,7 @@
   "exit_button": "退出",
   "discord_server_button": "Discord 服务器",
   "languages_button": "语言",
+  "p2mm_folder": "打开 P2:MM 文件夹",
   "github_button": "GitHub",
   "admins_button": "管理员",
   "settings_button": "设置",

--- a/src/Languages/繁體中文 (Traditional Chinese).json
+++ b/src/Languages/繁體中文 (Traditional Chinese).json
@@ -6,6 +6,7 @@
   "exit_button": "退出",
   "discord_server_button": "Discord 伺服器",
   "languages_button": "語言",
+  "p2mm_folder": "打開 P2:MM 資料夾",
   "github_button": "GitHub",
   "admins_button": "管理員",
   "settings_button": "設置",

--- a/src/Languages/한국어 (Korean).json
+++ b/src/Languages/한국어 (Korean).json
@@ -6,6 +6,7 @@
     "exit_button": "종료",
     "discord_server_button": "Discord 서버",
     "languages_button": "언어",
+    "p2mm_folder": "P2:MM 폴더 열기",
     "github_button": "Github",
     "admins_button": "어드민",
     "settings_button": "환경설정",

--- a/src/MainWindow.py
+++ b/src/MainWindow.py
@@ -175,6 +175,15 @@ class Gui:
     def Button_LanguageMenu_func(self) -> None:
         self.ChangeView(Views.LanguageMenu)
 
+    # Opens the folder where launcher config files are stored (GVars.modPath)
+    def Button_OpenApp_Folder_func(self) -> None:
+        if (sys.platform == "win32"):
+            os.startfile(GVars.modPath)
+        elif (sys.platform.startswith("linux")):
+            subprocess.Popen(["xdg-open", GVars.modPath])
+        else:
+            Log("Your operating system is not supported!")
+
     # Access to the launchers Developer settings
     def Button_DevSettings_func(self) -> None:
         self.RefreshSettingsMenu("dev")

--- a/src/Scripts/GlobalVariables.py
+++ b/src/Scripts/GlobalVariables.py
@@ -33,11 +33,11 @@ def init() -> None:
 
         # Again thanks stackOverflow for this
         # This code allows us to get the document's folder on any windows pc with any language
-        CSIDL_PERSONAL = 5       # My Documents
+        CSIDL_APPDATA = 26       # %APPDATA%
         SHGFP_TYPE_CURRENT = 0   # Get current, not default value
 
         buf = ctypes.create_unicode_buffer(ctypes.wintypes.MAX_PATH)
-        ctypes.windll.shell32.SHGetFolderPathW(None, CSIDL_PERSONAL, None, SHGFP_TYPE_CURRENT, buf)
+        ctypes.windll.shell32.SHGetFolderPathW(None, CSIDL_APPDATA, None, SHGFP_TYPE_CURRENT, buf)
 
         # Set the modPath to the users documents folder
         modPath = buf.value + os.sep + "p2mm"

--- a/src/Scripts/Views.py
+++ b/src/Scripts/Views.py
@@ -57,13 +57,13 @@ def SettingsMenu(ui: Gui) -> None:
         GVars.translations["admins_button"], ui.Button_AdminsMenu_func, (0, 255, 255))
     Button_LanguageMenu = Button(
         GVars.translations["languages_button"], ui.Button_LanguageMenu_func, (175, 75, 0))
-    Button_P2mmFolder = Button(
+    Button_P2MMFolder = Button(
         GVars.translations["p2mm_folder"], ui.Button_OpenApp_Folder_func, (120, 255, 120))
     Button_Back = Button(
         GVars.translations["back_button"], ui.Button_Back_func)
     
     Buttons = [Button_GeneralSettingsMenu, Button_AdvancedSettingsMenu,
-               Button_AdminsMenu, Button_LanguageMenu, Button_P2mmFolder]
+               Button_AdminsMenu, Button_LanguageMenu, Button_P2MMFolder]
 
     if ui.DevMode:
         Button_HiddenSettings = Button(

--- a/src/Scripts/Views.py
+++ b/src/Scripts/Views.py
@@ -57,11 +57,13 @@ def SettingsMenu(ui: Gui) -> None:
         GVars.translations["admins_button"], ui.Button_AdminsMenu_func, (0, 255, 255))
     Button_LanguageMenu = Button(
         GVars.translations["languages_button"], ui.Button_LanguageMenu_func, (175, 75, 0))
+    Button_P2mmFolder = Button(
+        GVars.translations["p2mm_folder"], ui.Button_OpenApp_Folder_func, (120, 255, 120))
     Button_Back = Button(
         GVars.translations["back_button"], ui.Button_Back_func)
     
     Buttons = [Button_GeneralSettingsMenu, Button_AdvancedSettingsMenu,
-               Button_AdminsMenu, Button_LanguageMenu]
+               Button_AdminsMenu, Button_LanguageMenu, Button_P2mmFolder]
 
     if ui.DevMode:
         Button_HiddenSettings = Button(


### PR DESCRIPTION
On Windows, OneDrive can take over the My Documents folder, causing read/write protection errors for file I/O (particularly during updates). This PR:

- Changes the Windows config folder from My Documents to %APPDATA%
- Adds a button to the settings menu to open the config folder in file explorer
- Maintains the existing config path for Linux systems

Tested on both Windows and Steam Deck. UI translations done with Google Translate.
![image](https://github.com/user-attachments/assets/d82a0043-a32c-4c94-b713-e3c86035be6f)
